### PR TITLE
Cu 86b0zgw9z zoom ability

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -125,3 +125,5 @@ def load_vehicles(loaded_vehicles, vehicles, route_dict):
         new_vehicle = Vehicle(v["id"], route_dict[v["route"]], v["route_position"], 8, 0, 2.23, 4.90, 1.25, 'assets/sedan.png')
         vehicle_dict[v["id"]] = new_vehicle
         vehicles.append(new_vehicle)
+
+

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pygame
-from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
+from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT, MAX_ZOOM_FACTOR, MIN_ZOOM_FACTOR
 from manager.manager import Manager
 from pygame import Surface
 
 zoom_factor = 1
 
-def set_zoomed_helper(updated_zoomed):
+def set_zoomed_helper(updated_zoomed: float):
     global zoom_factor
     zoom_factor = updated_zoomed
 
@@ -83,3 +83,17 @@ def draw_radius_circle(screen: Surface, manager: Manager):
         pygame.draw.arc(screen, "green", arc_rect, 0, 2*np.pi)
 
     pygame.draw.circle(screen, "green", manager_screen_pos, circle_radius)
+
+def scroll_handler(event: pygame.event.Event, zoom_factor_simulator: float):
+
+    if event.y > 0:
+        zoom_factor_simulator *= 1.1
+        if zoom_factor_simulator > MAX_ZOOM_FACTOR:
+            zoom_factor_simulator = MAX_ZOOM_FACTOR
+    elif event.y < 0:
+        zoom_factor_simulator *= 0.9
+        if zoom_factor_simulator < MIN_ZOOM_FACTOR:
+            zoom_factor_simulator = MIN_ZOOM_FACTOR
+
+    set_zoomed_helper(zoom_factor_simulator)
+    return zoom_factor_simulator

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -19,70 +19,18 @@ def get_x_y_shift(screen: Surface):
     return x_shift, y_shift
 
 def world_to_screen_vector(screen: Surface, pos: np.ndarray) -> np.ndarray:
-    # not zoomed in when zoom_factor = 1 so we need to subtract by one for the condition below to be 
-    if zoom_factor - 1:
-        pos = zoom_and_adjust_positions_within_bounds(pos)
+    pos = np.array([pos[0] * zoom_factor,pos[1] * zoom_factor])
 
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     render_height = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     x_shift, y_shift = get_x_y_shift(screen)
     return np.array([(pos[0]+(WORLD_WIDTH/2))*render_width/WORLD_WIDTH+x_shift, (pos[1]+(WORLD_HEIGHT/2))*render_height/WORLD_HEIGHT+y_shift])
 
-def world_to_screen_scalar_exterior(screen: Surface, x: float) -> float:
+def world_to_screen_scalar(screen: Surface, x: float) -> float:
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
+    render_width = render_width * zoom_factor
 
     return x*render_width/WORLD_WIDTH
-
-# same functionality as world_to_screen_scalar_exterior but zoom operation is applied for objects ONLY within the simulation screen
-def world_to_screen_scalar_simulation_screen(screen: Surface, x: float) -> float:
-    world_to_screen_scalar_value = world_to_screen_scalar_exterior(screen, x)
-
-    if zoom_factor - 1:
-        world_to_screen_scalar_value = world_to_screen_scalar_value * zoom_factor
-
-    return world_to_screen_scalar_value
-
-def zoom_and_adjust_positions_within_bounds(position: np.ndarray) -> np.ndarray:
-    # check if position is out of screen, if so, keep it in screen right on the border
-    if position[0] * zoom_factor >= 0 and position[1] * zoom_factor >= 0:
-        zoomed_position = np.array([min(position[0] * zoom_factor, WORLD_WIDTH/2), min(position[1] * zoom_factor, WORLD_HEIGHT/2)])
-    
-    elif position[0] * zoom_factor >= 0 and position[1] * zoom_factor <= 0:
-        zoomed_position = np.array([min(position[0] * zoom_factor, WORLD_WIDTH/2), max(position[1] * zoom_factor, -WORLD_HEIGHT/2)])
-   
-    elif position[0] * zoom_factor <= 0 and position[1] * zoom_factor >= 0:
-        zoomed_position = np.array([max(position[0] * zoom_factor, -WORLD_WIDTH/2), min(position[1] * zoom_factor, WORLD_HEIGHT/2)])
-   
-    else:
-        zoomed_position = np.array([max(position[0] * zoom_factor, -WORLD_WIDTH/2), max(position[1] * zoom_factor, -WORLD_HEIGHT/2)])
-
-    return zoomed_position
-
-# render only if vehicle is positioned within zoomed screen
-def valid_vehicle_render_when_zoomed(vehicle_center_point: list):
-        if zoom_factor - 1:
-            zoomed_vehicle_center_point = zoom_and_adjust_positions_within_bounds(vehicle_center_point)
-            if abs(zoomed_vehicle_center_point[0]) == WORLD_WIDTH / 2 or abs(zoomed_vehicle_center_point[1]) == WORLD_HEIGHT / 2:
-                return False
-        return True
-        
-def draw_radius_circle(screen: Surface, manager: Manager):
-    radius = world_to_screen_scalar_simulation_screen(screen, manager.radius)
-    manager_screen_pos = world_to_screen_vector(screen, manager.position)
-
-    if zoom_factor - 1 :
-        circle_radius = 5*zoom_factor
-        diameter = radius*2*zoom_factor
-        
-    else:
-        circle_radius = 5
-        diameter = radius*2
-         # draw radius circle ONLY when complelety zoomed out
-        arc_rect = pygame.Rect(0,0,diameter,diameter)
-        arc_rect.center = world_to_screen_vector(screen, manager.position)
-        pygame.draw.arc(screen, "green", arc_rect, 0, 2*np.pi)
-
-    pygame.draw.circle(screen, "green", manager_screen_pos, circle_radius)
 
 def scroll_handler(event: pygame.event.Event, zoom_factor_simulator: float):
 

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -1,5 +1,6 @@
 import numpy as np
-from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
+import pygame
+from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT, ZOOM_FACTOR
 from pygame import Surface
 
 def get_x_y_shift(screen: Surface):
@@ -19,3 +20,39 @@ def world_to_screen_vector(screen: Surface, pos: np.ndarray) -> np.ndarray:
 def world_to_screen_scalar(screen: Surface, x: float) -> float:
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     return x*render_width/WORLD_WIDTH
+
+def zoom_and_adjust_positions_within_bounds(position: np.ndarray) -> np.ndarray:
+    # when x >= 0 (right side) and y >= 0 (below y-axis), take min(x, right border) and min(y, bottom border)
+    if position[0] * ZOOM_FACTOR >= 0 and position[1] * ZOOM_FACTOR >= 0:
+        zoomed_position = np.array([min(position[0] * ZOOM_FACTOR, WORLD_WIDTH/2), min(position[1] * ZOOM_FACTOR, WORLD_HEIGHT/2)])
+    
+    elif position[0] * ZOOM_FACTOR >= 0 and position[1] * ZOOM_FACTOR <= 0:
+        zoomed_position = np.array([min(position[0] * ZOOM_FACTOR, WORLD_WIDTH/2), max(position[1] * ZOOM_FACTOR, -WORLD_HEIGHT/2)])
+   
+    elif position[0] * ZOOM_FACTOR <= 0 and position[1] * ZOOM_FACTOR >= 0:
+        zoomed_position = np.array([max(position[0] * ZOOM_FACTOR, -WORLD_WIDTH/2), min(position[1] * ZOOM_FACTOR, WORLD_HEIGHT/2)])
+   
+    else:
+        zoomed_position = np.array([max(position[0] * ZOOM_FACTOR, -WORLD_WIDTH/2), max(position[1] * ZOOM_FACTOR, -WORLD_HEIGHT/2)])
+
+    return zoomed_position
+
+def render_CircularEdge(screen: Surface, center_position: np.ndarray, start_position: np.ndarray, end_position: np.ndarray, clockwise: bool) -> None:
+    # define rect
+    radius = world_to_screen_scalar(screen, np.linalg.norm(start_position-center_position)) # norm describes distance
+    diameter = radius*2
+    arc_rect = pygame.Rect(0,0,diameter,diameter)
+    arc_rect.center = world_to_screen_vector(screen, center_position)
+
+    theta_start = np.arctan2(-(start_position[1] - center_position[1]), start_position[0] - center_position[0])
+    theta_end = np.arctan2(-(end_position[1] - center_position[1]), end_position[0] - center_position[0])
+
+    if clockwise:
+        if theta_end < theta_start:
+            theta_end += 2*np.pi
+        theta_end, theta_start = theta_start, theta_end
+    else:
+        if theta_start < theta_end:
+            theta_start += 2*np.pi
+
+    pygame.draw.arc(screen, "red", arc_rect, theta_start, theta_end)

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -1,7 +1,13 @@
 import numpy as np
 import pygame
-from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT, ZOOM_FACTOR
+from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
 from pygame import Surface
+
+zoom_factor = 1
+
+def get_zoomed_helper(updated_zoomed):
+    global zoom_factor
+    zoom_factor = updated_zoomed
 
 def get_x_y_shift(screen: Surface):
     x_shift = 0
@@ -11,8 +17,9 @@ def get_x_y_shift(screen: Surface):
         x_shift = difference / 2
     return x_shift, y_shift
 
-def world_to_screen_vector(screen: Surface, pos: np.ndarray, zoomed: bool) -> np.ndarray:
-    if zoomed:
+def world_to_screen_vector(screen: Surface, pos: np.ndarray) -> np.ndarray:
+    # not zoomed in when zoom_factor = 1 so we need to subtract by one for the condition below to be False
+    if zoom_factor - 1:
         pos = zoom_and_adjust_positions_within_bounds(pos)
 
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
@@ -26,17 +33,17 @@ def world_to_screen_scalar(screen: Surface, x: float) -> float:
 
 def zoom_and_adjust_positions_within_bounds(position: np.ndarray) -> np.ndarray:
     # check if position is out of screen, if so, keep it in screen right on the border
-    if position[0] * ZOOM_FACTOR >= 0 and position[1] * ZOOM_FACTOR >= 0:
-        zoomed_position = np.array([min(position[0] * ZOOM_FACTOR, WORLD_WIDTH/2), min(position[1] * ZOOM_FACTOR, WORLD_HEIGHT/2)])
+    if position[0] * zoom_factor >= 0 and position[1] * zoom_factor >= 0:
+        zoomed_position = np.array([min(position[0] * zoom_factor, WORLD_WIDTH/2), min(position[1] * zoom_factor, WORLD_HEIGHT/2)])
     
-    elif position[0] * ZOOM_FACTOR >= 0 and position[1] * ZOOM_FACTOR <= 0:
-        zoomed_position = np.array([min(position[0] * ZOOM_FACTOR, WORLD_WIDTH/2), max(position[1] * ZOOM_FACTOR, -WORLD_HEIGHT/2)])
+    elif position[0] * zoom_factor >= 0 and position[1] * zoom_factor <= 0:
+        zoomed_position = np.array([min(position[0] * zoom_factor, WORLD_WIDTH/2), max(position[1] * zoom_factor, -WORLD_HEIGHT/2)])
    
-    elif position[0] * ZOOM_FACTOR <= 0 and position[1] * ZOOM_FACTOR >= 0:
-        zoomed_position = np.array([max(position[0] * ZOOM_FACTOR, -WORLD_WIDTH/2), min(position[1] * ZOOM_FACTOR, WORLD_HEIGHT/2)])
+    elif position[0] * zoom_factor <= 0 and position[1] * zoom_factor >= 0:
+        zoomed_position = np.array([max(position[0] * zoom_factor, -WORLD_WIDTH/2), min(position[1] * zoom_factor, WORLD_HEIGHT/2)])
    
     else:
-        zoomed_position = np.array([max(position[0] * ZOOM_FACTOR, -WORLD_WIDTH/2), max(position[1] * ZOOM_FACTOR, -WORLD_HEIGHT/2)])
+        zoomed_position = np.array([max(position[0] * zoom_factor, -WORLD_WIDTH/2), max(position[1] * zoom_factor, -WORLD_HEIGHT/2)])
 
     return zoomed_position
 

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pygame
 from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
+from manager.manager import Manager
 from pygame import Surface
 
 zoom_factor = 1
 
-def get_zoomed_helper(updated_zoomed):
+def set_zoomed_helper(updated_zoomed):
     global zoom_factor
     zoom_factor = updated_zoomed
 
@@ -18,7 +19,7 @@ def get_x_y_shift(screen: Surface):
     return x_shift, y_shift
 
 def world_to_screen_vector(screen: Surface, pos: np.ndarray) -> np.ndarray:
-    # not zoomed in when zoom_factor = 1 so we need to subtract by one for the condition below to be False
+    # not zoomed in when zoom_factor = 1 so we need to subtract by one for the condition below to be 
     if zoom_factor - 1:
         pos = zoom_and_adjust_positions_within_bounds(pos)
 
@@ -27,9 +28,19 @@ def world_to_screen_vector(screen: Surface, pos: np.ndarray) -> np.ndarray:
     x_shift, y_shift = get_x_y_shift(screen)
     return np.array([(pos[0]+(WORLD_WIDTH/2))*render_width/WORLD_WIDTH+x_shift, (pos[1]+(WORLD_HEIGHT/2))*render_height/WORLD_HEIGHT+y_shift])
 
-def world_to_screen_scalar(screen: Surface, x: float) -> float:
+def world_to_screen_scalar_exterior(screen: Surface, x: float) -> float:
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
+
     return x*render_width/WORLD_WIDTH
+
+# same functionality as world_to_screen_scalar_exterior but zoom operation is applied for objects ONLY within the simulation screen
+def world_to_screen_scalar_simulation_screen(screen: Surface, x: float) -> float:
+    world_to_screen_scalar_value = world_to_screen_scalar_exterior(screen, x)
+
+    if zoom_factor - 1:
+        world_to_screen_scalar_value = world_to_screen_scalar_value * zoom_factor
+
+    return world_to_screen_scalar_value
 
 def zoom_and_adjust_positions_within_bounds(position: np.ndarray) -> np.ndarray:
     # check if position is out of screen, if so, keep it in screen right on the border
@@ -47,3 +58,28 @@ def zoom_and_adjust_positions_within_bounds(position: np.ndarray) -> np.ndarray:
 
     return zoomed_position
 
+# render only if vehicle is positioned within zoomed screen
+def valid_vehicle_render_when_zoomed(vehicle_center_point: list):
+        if zoom_factor - 1:
+            zoomed_vehicle_center_point = zoom_and_adjust_positions_within_bounds(vehicle_center_point)
+            if abs(zoomed_vehicle_center_point[0]) == WORLD_WIDTH / 2 or abs(zoomed_vehicle_center_point[1]) == WORLD_HEIGHT / 2:
+                return False
+        return True
+        
+def draw_radius_circle(screen: Surface, manager: Manager):
+    radius = world_to_screen_scalar_simulation_screen(screen, manager.radius)
+    manager_screen_pos = world_to_screen_vector(screen, manager.position)
+
+    if zoom_factor - 1 :
+        circle_radius = 5*zoom_factor
+        diameter = radius*2*zoom_factor
+        
+    else:
+        circle_radius = 5
+        diameter = radius*2
+         # draw radius circle ONLY when complelety zoomed out
+        arc_rect = pygame.Rect(0,0,diameter,diameter)
+        arc_rect.center = world_to_screen_vector(screen, manager.position)
+        pygame.draw.arc(screen, "green", arc_rect, 0, 2*np.pi)
+
+    pygame.draw.circle(screen, "green", manager_screen_pos, circle_radius)

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -22,7 +22,7 @@ def world_to_screen_scalar(screen: Surface, x: float) -> float:
     return x*render_width/WORLD_WIDTH
 
 def zoom_and_adjust_positions_within_bounds(position: np.ndarray) -> np.ndarray:
-    # when x >= 0 (right side) and y >= 0 (below y-axis), take min(x, right border) and min(y, bottom border)
+    # check if position is out of screen, if so, keep it in screen right on the border
     if position[0] * ZOOM_FACTOR >= 0 and position[1] * ZOOM_FACTOR >= 0:
         zoomed_position = np.array([min(position[0] * ZOOM_FACTOR, WORLD_WIDTH/2), min(position[1] * ZOOM_FACTOR, WORLD_HEIGHT/2)])
     

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -4,12 +4,6 @@ from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT, MAX_ZOOM_FACTO
 from manager.manager import Manager
 from pygame import Surface
 
-zoom_factor = 1
-
-def set_zoomed_helper(updated_zoomed: float):
-    global zoom_factor
-    zoom_factor = updated_zoomed
-
 def get_x_y_shift(screen: Surface):
     x_shift = 0
     y_shift = 0
@@ -18,15 +12,15 @@ def get_x_y_shift(screen: Surface):
         x_shift = difference / 2
     return x_shift, y_shift
 
-def world_to_screen_vector(screen: Surface, pos: np.ndarray) -> np.ndarray:
-    pos = np.array([pos[0] * zoom_factor,pos[1] * zoom_factor])
+def world_to_screen_vector(screen: Surface, pos: np.ndarray, zoom_factor: float) -> np.ndarray:
+    pos = np.array([pos[0] * zoom_factor, pos[1] * zoom_factor])
 
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     render_height = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     x_shift, y_shift = get_x_y_shift(screen)
     return np.array([(pos[0]+(WORLD_WIDTH/2))*render_width/WORLD_WIDTH+x_shift, (pos[1]+(WORLD_HEIGHT/2))*render_height/WORLD_HEIGHT+y_shift])
 
-def world_to_screen_scalar(screen: Surface, x: float) -> float:
+def world_to_screen_scalar(screen: Surface, x: float, zoom_factor: float) -> float:
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     render_width = render_width * zoom_factor
 
@@ -43,5 +37,4 @@ def scroll_handler(event: pygame.event.Event, zoom_factor_simulator: float):
         if zoom_factor_simulator < MIN_ZOOM_FACTOR:
             zoom_factor_simulator = MIN_ZOOM_FACTOR
 
-    set_zoomed_helper(zoom_factor_simulator)
     return zoom_factor_simulator

--- a/src/simulator/helper.py
+++ b/src/simulator/helper.py
@@ -11,7 +11,10 @@ def get_x_y_shift(screen: Surface):
         x_shift = difference / 2
     return x_shift, y_shift
 
-def world_to_screen_vector(screen: Surface, pos: np.ndarray) -> np.ndarray:
+def world_to_screen_vector(screen: Surface, pos: np.ndarray, zoomed: bool) -> np.ndarray:
+    if zoomed:
+        pos = zoom_and_adjust_positions_within_bounds(pos)
+
     render_width = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     render_height = min(screen.get_width(), screen.get_height()-TOOLBAR_HEIGHT)
     x_shift, y_shift = get_x_y_shift(screen)
@@ -37,22 +40,3 @@ def zoom_and_adjust_positions_within_bounds(position: np.ndarray) -> np.ndarray:
 
     return zoomed_position
 
-def render_CircularEdge(screen: Surface, center_position: np.ndarray, start_position: np.ndarray, end_position: np.ndarray, clockwise: bool) -> None:
-    # define rect
-    radius = world_to_screen_scalar(screen, np.linalg.norm(start_position-center_position)) # norm describes distance
-    diameter = radius*2
-    arc_rect = pygame.Rect(0,0,diameter,diameter)
-    arc_rect.center = world_to_screen_vector(screen, center_position)
-
-    theta_start = np.arctan2(-(start_position[1] - center_position[1]), start_position[0] - center_position[0])
-    theta_end = np.arctan2(-(end_position[1] - center_position[1]), end_position[0] - center_position[0])
-
-    if clockwise:
-        if theta_end < theta_start:
-            theta_end += 2*np.pi
-        theta_end, theta_start = theta_start, theta_end
-    else:
-        if theta_start < theta_end:
-            theta_start += 2*np.pi
-
-    pygame.draw.arc(screen, "red", arc_rect, theta_start, theta_end)

--- a/src/simulator/render.py
+++ b/src/simulator/render.py
@@ -7,7 +7,7 @@ from classes.edge import Edge, StraightEdge, CircularEdge
 from classes.route import Route, route_position_to_world_position, direction_at_route_position
 from manager.manager import Manager
 from classes.button import Button
-from .helper import world_to_screen_vector, world_to_screen_scalar_exterior, world_to_screen_scalar_simulation_screen, valid_vehicle_render_when_zoomed, draw_radius_circle
+from .helper import world_to_screen_vector, world_to_screen_scalar
 from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
 
 pygame.font.init()
@@ -26,7 +26,7 @@ def render_edges(screen: Surface, edges: list[Edge]):
             pygame.draw.line(screen, "red", start_position, end_position)
         elif isinstance(edge, CircularEdge):
             # define rect
-            radius = world_to_screen_scalar_simulation_screen(screen, np.linalg.norm(edge.start.position-edge.center)) # norm describes distance
+            radius = world_to_screen_scalar(screen, np.linalg.norm(edge.start.position-edge.center)) # norm describes distance
             diameter = radius*2
             arc_rect = pygame.Rect(0,0,diameter,diameter)
             arc_rect.center = world_to_screen_vector(screen, edge.center)
@@ -51,31 +51,29 @@ def render_intersections(screen: Surface, intersection_points):
 
 def render_vehicles(screen: Surface, vehicles: list[Vehicle]):
     for vehicle in vehicles:
-        vehicle_screen_width = world_to_screen_scalar_simulation_screen(screen, vehicle.width)
-        vehicle_screen_length = world_to_screen_scalar_simulation_screen(screen, vehicle.length)
+        vehicle_screen_width = world_to_screen_scalar(screen, vehicle.width)
+        vehicle_screen_length = world_to_screen_scalar(screen, vehicle.length)
         
         vehicle_center_point = route_position_to_world_position(vehicle.route, vehicle.route_position)
-
-        if valid_vehicle_render_when_zoomed(vehicle_center_point):
-            vehicle_center_screen_pos = world_to_screen_vector(screen, vehicle_center_point)
-            img = pygame.transform.smoothscale(vehicle.image, (vehicle_screen_length, vehicle_screen_width))
-            vehicle_angle = direction_at_route_position(vehicle.route, vehicle.route_position)
-            img = pygame.transform.rotate(img, vehicle_angle)
-            car_rect = img.get_rect()
-            car_rect.center = vehicle_center_screen_pos
-            screen.blit(img, car_rect)
-            pygame.draw.circle(screen, "red", vehicle_center_screen_pos, 3)
+        vehicle_center_screen_pos = world_to_screen_vector(screen, vehicle_center_point)
+        img = pygame.transform.smoothscale(vehicle.image, (vehicle_screen_length, vehicle_screen_width))
+        vehicle_angle = direction_at_route_position(vehicle.route, vehicle.route_position)
+        img = pygame.transform.rotate(img, vehicle_angle)
+        car_rect = img.get_rect()
+        car_rect.center = vehicle_center_screen_pos
+        screen.blit(img, car_rect)
+        pygame.draw.circle(screen, "red", vehicle_center_screen_pos, 3)
 
 def render_background(screen: Surface):
     position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2])
-    width = world_to_screen_scalar_exterior(screen, WORLD_WIDTH)
-    height = world_to_screen_scalar_exterior(screen, WORLD_HEIGHT)
+    width = world_to_screen_scalar(screen, WORLD_WIDTH)
+    height = world_to_screen_scalar(screen, WORLD_HEIGHT)
     pygame.draw.rect(screen, "grey", pygame.Rect(position[0], position[1], width, height))
 
 def render_border(screen: Surface):
     position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2])
-    width = world_to_screen_scalar_exterior(screen, WORLD_WIDTH)
-    height = world_to_screen_scalar_exterior(screen, WORLD_HEIGHT)
+    width = world_to_screen_scalar(screen, WORLD_WIDTH)
+    height = world_to_screen_scalar(screen, WORLD_HEIGHT)
     pygame.draw.rect(screen, "maroon", pygame.Rect(position[0]-3, position[1]-3, width+6, height+6),3)
 
 def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_visible: bool, intersection_points):
@@ -89,7 +87,15 @@ def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_vi
     # render_scenery()
 
 def render_manager(screen: Surface, manager: Manager):
-    draw_radius_circle(screen, manager)
+    radius = world_to_screen_scalar(screen, manager.radius)
+    manager_screen_pos = world_to_screen_vector(screen, manager.position)
+
+    circle_radius = 5 # px
+    diameter = radius*2
+    arc_rect = pygame.Rect(0,0,diameter,diameter)
+    arc_rect.center = world_to_screen_vector(screen, manager.position)
+    pygame.draw.arc(screen, "green", arc_rect, 0, 2*np.pi)
+    pygame.draw.circle(screen, "green", manager_screen_pos, circle_radius)
     
     for i, vehicle in enumerate(manager.vehicles):
         font = pygame.font.SysFont('Segoe UI', 15)
@@ -122,4 +128,4 @@ def render_title(screen):
     # draw title and version
     FONT = pygame.font.SysFont("Segoe UI", 15, bold=True, italic=False)
     text_surface = FONT.render(f"Concurent Traffic v0.0.2", True, (255, 255, 255))
-    screen.blit(text_surface, (6,624))
+    screen.blit(text_surface, (6,screen.get_height()-TOOLBAR_HEIGHT+6))

--- a/src/simulator/render.py
+++ b/src/simulator/render.py
@@ -13,23 +13,29 @@ from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
 pygame.font.init()
 FONT = pygame.font.SysFont('Consolas', 20)
 
+zoom_factor = 1
+
+def set_zoomed_render(updated_zoomed: float):
+    global zoom_factor
+    zoom_factor = updated_zoomed
+
 def render_nodes(screen: Surface, nodes: list[Node]):
     for node in nodes:
-        node_position = world_to_screen_vector(screen, node.position)
+        node_position = world_to_screen_vector(screen, node.position, zoom_factor)
         pygame.draw.circle(screen, "red", node_position, 3)
 
 def render_edges(screen: Surface, edges: list[Edge]):
     for edge in edges:
         if isinstance(edge, StraightEdge):
-            start_position = world_to_screen_vector(screen, edge.start.position)
-            end_position   = world_to_screen_vector(screen, edge.end.position)
+            start_position = world_to_screen_vector(screen, edge.start.position, zoom_factor)
+            end_position   = world_to_screen_vector(screen, edge.end.position, zoom_factor)
             pygame.draw.line(screen, "red", start_position, end_position)
         elif isinstance(edge, CircularEdge):
             # define rect
-            radius = world_to_screen_scalar(screen, np.linalg.norm(edge.start.position-edge.center)) # norm describes distance
+            radius = world_to_screen_scalar(screen, np.linalg.norm(edge.start.position-edge.center), zoom_factor) # norm describes distance
             diameter = radius*2
             arc_rect = pygame.Rect(0,0,diameter,diameter)
-            arc_rect.center = world_to_screen_vector(screen, edge.center)
+            arc_rect.center = world_to_screen_vector(screen, edge.center, zoom_factor)
 
             theta_start = np.arctan2(-(edge.start.position[1] - edge.center[1]), edge.start.position[0] - edge.center[0])
             theta_end = np.arctan2(-(edge.end.position[1] - edge.center[1]), edge.end.position[0] - edge.center[0])
@@ -46,16 +52,16 @@ def render_edges(screen: Surface, edges: list[Edge]):
 
 def render_intersections(screen: Surface, intersection_points):
     for intersection in intersection_points:
-        node_position = world_to_screen_vector(screen, np.array(list(intersection[2])))
+        node_position = world_to_screen_vector(screen, np.array(list(intersection[2])), zoom_factor)
         pygame.draw.circle(screen, "blue", node_position, 3)
 
 def render_vehicles(screen: Surface, vehicles: list[Vehicle]):
     for vehicle in vehicles:
-        vehicle_screen_width = world_to_screen_scalar(screen, vehicle.width)
-        vehicle_screen_length = world_to_screen_scalar(screen, vehicle.length)
+        vehicle_screen_width = world_to_screen_scalar(screen, vehicle.width, zoom_factor)
+        vehicle_screen_length = world_to_screen_scalar(screen, vehicle.length, zoom_factor)
         
         vehicle_center_point = route_position_to_world_position(vehicle.route, vehicle.route_position)
-        vehicle_center_screen_pos = world_to_screen_vector(screen, vehicle_center_point)
+        vehicle_center_screen_pos = world_to_screen_vector(screen, vehicle_center_point, zoom_factor)
         img = pygame.transform.smoothscale(vehicle.image, (vehicle_screen_length, vehicle_screen_width))
         vehicle_angle = direction_at_route_position(vehicle.route, vehicle.route_position)
         img = pygame.transform.rotate(img, vehicle_angle)
@@ -65,15 +71,15 @@ def render_vehicles(screen: Surface, vehicles: list[Vehicle]):
         pygame.draw.circle(screen, "red", vehicle_center_screen_pos, 3)
 
 def render_background(screen: Surface):
-    position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2])
-    width = world_to_screen_scalar(screen, WORLD_WIDTH)
-    height = world_to_screen_scalar(screen, WORLD_HEIGHT)
+    position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2], zoom_factor)
+    width = world_to_screen_scalar(screen, WORLD_WIDTH, zoom_factor)
+    height = world_to_screen_scalar(screen, WORLD_HEIGHT, zoom_factor)
     pygame.draw.rect(screen, "grey", pygame.Rect(position[0], position[1], width, height))
 
 def render_border(screen: Surface):
-    position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2])
-    width = world_to_screen_scalar(screen, WORLD_WIDTH)
-    height = world_to_screen_scalar(screen, WORLD_HEIGHT)
+    position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2], zoom_factor)
+    width = world_to_screen_scalar(screen, WORLD_WIDTH, zoom_factor)
+    height = world_to_screen_scalar(screen, WORLD_HEIGHT, zoom_factor)
     pygame.draw.rect(screen, "maroon", pygame.Rect(position[0]-3, position[1]-3, width+6, height+6),3)
 
 def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_visible: bool, intersection_points):
@@ -87,13 +93,13 @@ def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_vi
     # render_scenery()
 
 def render_manager(screen: Surface, manager: Manager):
-    radius = world_to_screen_scalar(screen, manager.radius)
-    manager_screen_pos = world_to_screen_vector(screen, manager.position)
+    radius = world_to_screen_scalar(screen, manager.radius, zoom_factor)
+    manager_screen_pos = world_to_screen_vector(screen, manager.position, zoom_factor)
 
     circle_radius = 5 # px
     diameter = radius*2
     arc_rect = pygame.Rect(0,0,diameter,diameter)
-    arc_rect.center = world_to_screen_vector(screen, manager.position)
+    arc_rect.center = world_to_screen_vector(screen, manager.position, zoom_factor)
     pygame.draw.arc(screen, "green", arc_rect, 0, 2*np.pi)
     pygame.draw.circle(screen, "green", manager_screen_pos, circle_radius)
     

--- a/src/simulator/render.py
+++ b/src/simulator/render.py
@@ -7,65 +7,85 @@ from classes.edge import Edge, StraightEdge, CircularEdge
 from classes.route import Route, route_position_to_world_position, direction_at_route_position
 from manager.manager import Manager
 from classes.button import Button
-from .helper import world_to_screen_vector, world_to_screen_scalar
-from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
+from .helper import world_to_screen_vector, world_to_screen_scalar, zoom_and_adjust_positions_within_bounds, render_CircularEdge
+from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT, ZOOM_FACTOR
 
 pygame.font.init()
 FONT = pygame.font.SysFont('Consolas', 20)
 
-def render_nodes(screen: Surface, nodes: list[Node]):
+def render_nodes(screen: Surface, nodes: list[Node], zoomed: bool):
     for node in nodes:
-        node_position = world_to_screen_vector(screen, node.position)
-        pygame.draw.circle(screen, "red", node_position, 3)
+        if zoomed:
+            node_position = world_to_screen_vector(screen, zoom_and_adjust_positions_within_bounds(node.position))
+            pygame.draw.circle(screen, "red", node_position, 3)
+        else:
+            node_position = world_to_screen_vector(screen, node.position)
+            pygame.draw.circle(screen, "red", node_position, 3)
 
-def render_edges(screen: Surface, edges: list[Edge]):
+def render_edges(screen: Surface, edges: list[Edge], zoomed: bool):
     for edge in edges:
         if isinstance(edge, StraightEdge):
-            start_position = world_to_screen_vector(screen, edge.start.position)
-            end_position   = world_to_screen_vector(screen, edge.end.position)
-            pygame.draw.line(screen, "red", start_position, end_position)
-        elif isinstance(edge, CircularEdge):
-            # define rect
-            radius = world_to_screen_scalar(screen, np.linalg.norm(edge.start.position-edge.center)) # norm describes distance
-            diameter = radius*2
-            arc_rect = pygame.Rect(0,0,diameter,diameter)
-            arc_rect.center = world_to_screen_vector(screen, edge.center)
-
-            theta_start = np.arctan2(-(edge.start.position[1] - edge.center[1]), edge.start.position[0] - edge.center[0])
-            theta_end = np.arctan2(-(edge.end.position[1] - edge.center[1]), edge.end.position[0] - edge.center[0])
-
-            if edge.clockwise:
-                if theta_end < theta_start:
-                    theta_end += 2*np.pi
-                theta_end, theta_start = theta_start, theta_end
+            if zoomed:
+                zoomed_start_position = world_to_screen_vector(screen, zoom_and_adjust_positions_within_bounds(edge.start.position))
+                zoomed_end_position   = world_to_screen_vector(screen, zoom_and_adjust_positions_within_bounds(edge.end.position))
+                pygame.draw.line(screen, "red", zoomed_start_position, zoomed_end_position)
             else:
-                if theta_start < theta_end:
-                    theta_start += 2*np.pi
+                start_position = world_to_screen_vector(screen, edge.start.position)
+                end_position   = world_to_screen_vector(screen, edge.end.position)
+                pygame.draw.line(screen, "red", start_position, end_position)
+        elif isinstance(edge, CircularEdge):
+            if zoomed:
+                # zoom all positions 
+                zoomed_center_position = zoom_and_adjust_positions_within_bounds(edge.center)
+                zoomed_start_position  = zoom_and_adjust_positions_within_bounds(edge.start.position)
+                zoomed_end_position    = zoom_and_adjust_positions_within_bounds(edge.end.position)
 
-            pygame.draw.arc(screen, "red", arc_rect, theta_start, theta_end)
+                render_CircularEdge(screen, zoomed_center_position, zoomed_start_position, zoomed_end_position, edge.clockwise)
+            
+            else:
+                render_CircularEdge(screen, edge.center, edge.start.position, edge.end.position, edge.clockwise)
 
 def render_intersections(screen: Surface, intersection_points):
     for intersection in intersection_points:
         node_position = world_to_screen_vector(screen, np.array(list(intersection[2])))
         pygame.draw.circle(screen, "blue", node_position, 3)
 
-def render_vehicles(screen: Surface, vehicles: list[Vehicle]):
+def render_vehicles(screen: Surface, vehicles: list[Vehicle], zoomed: bool):
     for vehicle in vehicles:
-        vehicle_screen_width = world_to_screen_scalar(screen, vehicle.width)
-        vehicle_screen_length = world_to_screen_scalar(screen, vehicle.length)
+        if zoomed:
+            vehicle_screen_width = world_to_screen_scalar(screen, vehicle.width)
+            vehicle_screen_length = world_to_screen_scalar(screen, vehicle.length)
 
-        vehicle_center_point = route_position_to_world_position(vehicle.route, vehicle.route_position)
-        vehicle_center_screen_pos = world_to_screen_vector(screen, vehicle_center_point)
+            vehicle_center_point = zoom_and_adjust_positions_within_bounds(route_position_to_world_position(vehicle.route, vehicle.route_position))
+            vehicle_center_screen_pos = (world_to_screen_vector(screen, vehicle_center_point))
 
-        img = pygame.transform.smoothscale(vehicle.image, (vehicle_screen_length, vehicle_screen_width))
-        vehicle_angle = direction_at_route_position(vehicle.route, vehicle.route_position)
-        img = pygame.transform.rotate(img, vehicle_angle)
+            img = pygame.transform.smoothscale(vehicle.image, (vehicle_screen_length, vehicle_screen_width))
 
-        car_rect = img.get_rect()
-        car_rect.center = vehicle_center_screen_pos
-        screen.blit(img, car_rect)
+            vehicle_angle = direction_at_route_position(vehicle.route, vehicle.route_position)
 
-        pygame.draw.circle(screen, "red", vehicle_center_screen_pos, 3)
+            img = pygame.transform.rotate(img, vehicle_angle)
+
+            car_rect = img.get_rect()
+            car_rect.center = vehicle_center_screen_pos
+            screen.blit(img, car_rect)
+
+            pygame.draw.circle(screen, "red", vehicle_center_screen_pos, 3)
+        else:
+            vehicle_screen_width = world_to_screen_scalar(screen, vehicle.width)
+            vehicle_screen_length = world_to_screen_scalar(screen, vehicle.length)
+
+            vehicle_center_point = route_position_to_world_position(vehicle.route, vehicle.route_position)
+            vehicle_center_screen_pos = world_to_screen_vector(screen, vehicle_center_point)
+
+            img = pygame.transform.smoothscale(vehicle.image, (vehicle_screen_length, vehicle_screen_width))
+            vehicle_angle = direction_at_route_position(vehicle.route, vehicle.route_position)
+            img = pygame.transform.rotate(img, vehicle_angle)
+
+            car_rect = img.get_rect()
+            car_rect.center = vehicle_center_screen_pos
+            screen.blit(img, car_rect)
+
+            pygame.draw.circle(screen, "red", vehicle_center_screen_pos, 3)
 
 def render_background(screen: Surface):
     position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2])
@@ -79,11 +99,39 @@ def render_border(screen: Surface):
     height = world_to_screen_scalar(screen, WORLD_HEIGHT)
     pygame.draw.rect(screen, "maroon", pygame.Rect(position[0]-3, position[1]-3, width+6, height+6),3)
 
-def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_visible: bool, intersection_points):
+def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_visible: bool, intersection_points, zoomed: bool):
     render_background(screen)
     if route_visible:
-        render_nodes(screen, nodes)
-        render_edges(screen, edges)
+        # if zoomed:
+        #     zoomed_nodes = []
+        #     for node in nodes:
+        #         zoomed_position = zoom_and_adjust_positions_within_bounds(node)
+        #         zoomed_nodes.append(Node(zoomed_position))
+
+        #     zoomed_edges = []
+        #     for edge in edges:
+        #         # have nodes within bounds of main screen to allow edges to render within main screen
+        #         zoomed_start_node_position = zoom_and_adjust_positions_within_bounds(edge.start)
+        #         zoomed_start_node = Node(zoomed_start_node_position)
+
+        #         zoomed_end_node_position = zoom_and_adjust_positions_within_bounds(edge.end)
+        #         zoomed_end_node = Node(zoomed_end_node_position)
+
+        #         if isinstance(edge, StraightEdge):
+        #             zoomed_edges.append(StraightEdge(edge.edge_id, zoomed_start_node, zoomed_end_node))
+        #         elif isinstance(edge, CircularEdge):
+        #             zoomed_center_position = np.array([edge.center[0] * ZOOM_FACTOR, edge.center[1] * ZOOM_FACTOR])
+        #             zoomed_edges.append(CircularEdge(edge.edge_id, zoomed_start_node, zoomed_end_node, zoomed_center_position, edge.clockwise))
+
+        #     render_nodes(screen, zoomed_nodes)
+        #     render_edges(screen, zoomed_edges)
+        #     render_border(screen)
+        # else:
+        #     render_nodes(screen, nodes)
+        #     render_edges(screen, edges)
+        render_nodes(screen, nodes, zoomed)
+        render_edges(screen, edges, zoomed)
+
     render_intersections(screen, intersection_points)
     render_border(screen)
     # render_scenery()

--- a/src/simulator/render.py
+++ b/src/simulator/render.py
@@ -7,16 +7,11 @@ from classes.edge import Edge, StraightEdge, CircularEdge
 from classes.route import Route, route_position_to_world_position, direction_at_route_position
 from manager.manager import Manager
 from classes.button import Button
-from .helper import world_to_screen_vector, world_to_screen_scalar, zoom_and_adjust_positions_within_bounds
+from .helper import world_to_screen_vector, world_to_screen_scalar_exterior, world_to_screen_scalar_simulation_screen, valid_vehicle_render_when_zoomed, draw_radius_circle
 from .simulator import WORLD_WIDTH, WORLD_HEIGHT, TOOLBAR_HEIGHT
 
 pygame.font.init()
 FONT = pygame.font.SysFont('Consolas', 20)
-zoom_factor = 1
-
-def get_zoomed_render(updated_zoomed):
-    global zoom_factor
-    zoom_factor = updated_zoomed
 
 def render_nodes(screen: Surface, nodes: list[Node]):
     for node in nodes:
@@ -31,10 +26,8 @@ def render_edges(screen: Surface, edges: list[Edge]):
             pygame.draw.line(screen, "red", start_position, end_position)
         elif isinstance(edge, CircularEdge):
             # define rect
-            radius = world_to_screen_scalar(screen, np.linalg.norm(edge.start.position-edge.center)) # norm describes distance
+            radius = world_to_screen_scalar_simulation_screen(screen, np.linalg.norm(edge.start.position-edge.center)) # norm describes distance
             diameter = radius*2
-            if zoom_factor - 1:
-                diameter *= zoom_factor
             arc_rect = pygame.Rect(0,0,diameter,diameter)
             arc_rect.center = world_to_screen_vector(screen, edge.center)
 
@@ -58,18 +51,12 @@ def render_intersections(screen: Surface, intersection_points):
 
 def render_vehicles(screen: Surface, vehicles: list[Vehicle]):
     for vehicle in vehicles:
-        vehicle_screen_width = world_to_screen_scalar(screen, vehicle.width)
-        vehicle_screen_length = world_to_screen_scalar(screen, vehicle.length)
+        vehicle_screen_width = world_to_screen_scalar_simulation_screen(screen, vehicle.width)
+        vehicle_screen_length = world_to_screen_scalar_simulation_screen(screen, vehicle.length)
         
         vehicle_center_point = route_position_to_world_position(vehicle.route, vehicle.route_position)
 
-        render_vehicle = True
-        if zoom_factor - 1:
-            zoomed_vehicle_center_point = zoom_and_adjust_positions_within_bounds(vehicle_center_point)
-            if abs(zoomed_vehicle_center_point[0]) == WORLD_WIDTH / 2 or abs(zoomed_vehicle_center_point[1]) == WORLD_HEIGHT / 2:
-                render_vehicle = False
-
-        if render_vehicle:
+        if valid_vehicle_render_when_zoomed(vehicle_center_point):
             vehicle_center_screen_pos = world_to_screen_vector(screen, vehicle_center_point)
             img = pygame.transform.smoothscale(vehicle.image, (vehicle_screen_length, vehicle_screen_width))
             vehicle_angle = direction_at_route_position(vehicle.route, vehicle.route_position)
@@ -81,14 +68,14 @@ def render_vehicles(screen: Surface, vehicles: list[Vehicle]):
 
 def render_background(screen: Surface):
     position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2])
-    width = world_to_screen_scalar(screen, WORLD_WIDTH)
-    height = world_to_screen_scalar(screen, WORLD_HEIGHT)
+    width = world_to_screen_scalar_exterior(screen, WORLD_WIDTH)
+    height = world_to_screen_scalar_exterior(screen, WORLD_HEIGHT)
     pygame.draw.rect(screen, "grey", pygame.Rect(position[0], position[1], width, height))
 
 def render_border(screen: Surface):
     position = world_to_screen_vector(screen, [-WORLD_WIDTH/2,-WORLD_HEIGHT/2])
-    width = world_to_screen_scalar(screen, WORLD_WIDTH)
-    height = world_to_screen_scalar(screen, WORLD_HEIGHT)
+    width = world_to_screen_scalar_exterior(screen, WORLD_WIDTH)
+    height = world_to_screen_scalar_exterior(screen, WORLD_HEIGHT)
     pygame.draw.rect(screen, "maroon", pygame.Rect(position[0]-3, position[1]-3, width+6, height+6),3)
 
 def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_visible: bool, intersection_points):
@@ -101,29 +88,15 @@ def render_world(screen: Surface, nodes: list[Node], edges: list[Edge], route_vi
     render_border(screen)
     # render_scenery()
 
-def render_manager(screen, manager):
-    radius = world_to_screen_scalar(screen, manager.radius)
-    manager_screen_pos = world_to_screen_vector(screen, manager.position)
-    if zoom_factor - 1 :
-        circle_radius = 5*zoom_factor
-        diameter = radius*2*zoom_factor
-        
-    else:
-        circle_radius = 5
-        diameter = radius*2
-         # draw radius circle ONLY when complelety zoomed out
-        arc_rect = pygame.Rect(0,0,diameter,diameter)
-        arc_rect.center = world_to_screen_vector(screen, manager.position)
-        pygame.draw.arc(screen, "green", arc_rect, 0, 2*np.pi)
-
-    pygame.draw.circle(screen, "green", manager_screen_pos, circle_radius)
-  
+def render_manager(screen: Surface, manager: Manager):
+    draw_radius_circle(screen, manager)
+    
     for i, vehicle in enumerate(manager.vehicles):
         font = pygame.font.SysFont('Segoe UI', 15)
         text_surface = font.render(f"id: {vehicle.id}, pos: {vehicle.route_position:.2f}", True, (0, 0, 0))
         screen.blit(text_surface, (5,i*20 + 5))
 
-def render_time(screen, toolbar_rect, time_elapsed): 
+def render_time(screen: Surface, toolbar_rect, time_elapsed): 
     font = pygame.font.SysFont('Segoe UI', 15)
     text_surface = font.render(f"Time: {time_elapsed:.3f}", True, (255, 255, 255))
     text_rect = text_surface.get_rect()
@@ -139,8 +112,8 @@ def render_buttons(screen: Surface, buttons: list[Button]) -> None:
             text = font.render(b.text, 1, (255, 255, 255))
             screen.blit(text, (b.x + (b.width/2 - text.get_width()/2), b.y + (b.height/2 - text.get_height()/2)))
 
-def render_toolbar(screen, time_elapsed, buttons):
+def render_toolbar(screen: Surface, time_elapsed, buttons: list[Button]):
     toolbar_rect = pygame.Rect(0, screen.get_height()-TOOLBAR_HEIGHT,screen.get_width(),TOOLBAR_HEIGHT)
     pygame.draw.rect(screen, pygame.Color(80,80,80), toolbar_rect)
-    render_time(screen,toolbar_rect, time_elapsed)
+    render_time(screen, toolbar_rect, time_elapsed)
     render_buttons(screen, buttons)

--- a/src/simulator/render.py
+++ b/src/simulator/render.py
@@ -110,7 +110,7 @@ def render_manager(screen, manager, zoomed: bool):
         pygame.draw.circle(screen, "green", manager_screen_pos, 5)
         radius = world_to_screen_scalar(screen, manager.radius)
 
-        # draw radius circle
+        # draw radius circle ONLY when zoomed out
         diameter = radius*2
         arc_rect = pygame.Rect(0,0,diameter,diameter)
         arc_rect.center = world_to_screen_vector(screen, manager.position)

--- a/src/simulator/simulator.py
+++ b/src/simulator/simulator.py
@@ -5,7 +5,6 @@ TOOLBAR_HEIGHT = 100
 
 MIN_ZOOM_FACTOR = 1
 MAX_ZOOM_FACTOR = 8
-zoom_factor = 1
 
 # world describes 160mx160m space
 WORLD_WIDTH = 160
@@ -32,6 +31,7 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
     running = True
     delta_time = 0
     time_elapsed = 0
+    zoom_factor = 1
 
     vehicles = vehicle_copy(initial_vehicles)
     is_run = True
@@ -58,13 +58,13 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
         nonlocal route_visible
         route_visible = not route_visible
 
-    def toggle_zoom() -> None: 
-        global zoom_factor
+    def toggle_zoom() -> None:
         if zoom_factor == 1:
             zoom_factor = MAX_ZOOM_FACTOR
         else:
-            zoom_factor = 1
-        set_zoomed_helper(zoom_factor)
+            zoom_factor = MIN_ZOOM_FACTOR
+        set_zoomed_helper()
+        
     
     toggle_button = Button((40, 40, 40), (255, 50, 50), (5, screen.get_height()-TOOLBAR_HEIGHT+50), (100, 30), 'toggle update', toggle_update, ())
     restart_button = Button((40, 40, 40), (255, 50, 50), (110, screen.get_height()-TOOLBAR_HEIGHT+50), (100, 30), 'restart', restart_func, ())
@@ -84,7 +84,6 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
                 [b.click() for b in buttons]
 
             elif event.type == pygame.MOUSEWHEEL:
-                global zoom_factor
                 zoom_factor = scroll_handler(event, zoom_factor)
 
         # fill the screen with a color to wipe away anything from last frame

--- a/src/simulator/simulator.py
+++ b/src/simulator/simulator.py
@@ -3,6 +3,8 @@ ORIGINAL_SCREEN_HEIGHT = 720
 
 TOOLBAR_HEIGHT = 100
 
+ZOOM_FACTOR = 8
+
 # world describes 160mx160m space
 WORLD_WIDTH = 160
 WORLD_HEIGHT = 160
@@ -31,6 +33,7 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
     vehicles = vehicle_copy(initial_vehicles)
     is_run = True
     route_visible = True
+    zoomed = False
 
     def toggle_update() -> None:
         nonlocal is_run
@@ -52,12 +55,18 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
     def toggle_route_visibility() -> None:
         nonlocal route_visible
         route_visible = not route_visible
+
+    def toggle_zoom() -> None:
+        nonlocal zoomed
+        zoomed = not zoomed
     
     toggle_button = Button((40, 40, 40), (255, 50, 50), (5, screen.get_height()-TOOLBAR_HEIGHT+50), (100, 30), 'toggle update', toggle_update, ())
     restart_button = Button((40, 40, 40), (255, 50, 50), (110, screen.get_height()-TOOLBAR_HEIGHT+50), (100, 30), 'restart', restart_func, ())
     routes_visibility_button = Button((40, 40, 40), (255, 50, 50), (215, screen.get_height()-TOOLBAR_HEIGHT+50), (150, 30), 'toggle route visibility', toggle_route_visibility, ())
+    zoom_button = Button((40, 40, 40), (255, 50, 50), (370, screen.get_height()-TOOLBAR_HEIGHT+50), (70, 30), 'zoom', toggle_zoom, ())
 
-    buttons = [toggle_button, restart_button, routes_visibility_button]
+
+    buttons = [toggle_button, restart_button, routes_visibility_button, zoom_button]
     while running:
         # poll for events
         # pygame.QUIT event means the user clicked X to close your window
@@ -72,9 +81,9 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
         screen.fill(pygame.Color(150,150,150))
 
         # optionally render nodes and edges. for now always on
-        render_world(screen, nodes, edges, route_visible, intersection_points)
+        render_world(screen, nodes, edges, route_visible, intersection_points, zoomed)
         render_manager(screen, manager)
-        render_vehicles(screen, vehicles)
+        render_vehicles(screen, vehicles, zoomed)
         render_toolbar(screen, time_elapsed, buttons)
 
         # manager 'cpu'

--- a/src/simulator/simulator.py
+++ b/src/simulator/simulator.py
@@ -82,7 +82,7 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
 
         # optionally render nodes and edges. for now always on
         render_world(screen, nodes, edges, route_visible, intersection_points, zoomed)
-        render_manager(screen, manager)
+        render_manager(screen, manager, zoomed)
         render_vehicles(screen, vehicles, zoomed)
         render_toolbar(screen, time_elapsed, buttons)
 

--- a/src/simulator/simulator.py
+++ b/src/simulator/simulator.py
@@ -20,9 +20,9 @@ from manager.manager import Manager, manager_event_loop
 from classes.node import Node
 from classes.edge import Edge
 from classes.route import Route
-from .render import render_world, render_manager, render_vehicles, render_buttons, render_time, render_toolbar, render_title
+from .render import render_world, render_manager, render_vehicles, render_buttons, render_time, render_toolbar, render_title, set_zoomed_render
 from .update import update_world
-from .helper import set_zoomed_helper, scroll_handler
+from .helper import scroll_handler
 
 def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: list[Edge], routes: list[Route], intersection_points, manager: Manager): # requires initialization of lanes, manager, vehicles
     pygame.init()
@@ -59,11 +59,12 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
         route_visible = not route_visible
 
     def toggle_zoom() -> None:
+        nonlocal zoom_factor
         if zoom_factor == 1:
             zoom_factor = MAX_ZOOM_FACTOR
         else:
             zoom_factor = MIN_ZOOM_FACTOR
-        set_zoomed_helper()
+        set_zoomed_render(zoom_factor)
         
     
     toggle_button = Button((40, 40, 40), (255, 50, 50), (5, screen.get_height()-TOOLBAR_HEIGHT+50), (100, 30), 'toggle update', toggle_update, ())
@@ -85,6 +86,7 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
 
             elif event.type == pygame.MOUSEWHEEL:
                 zoom_factor = scroll_handler(event, zoom_factor)
+                set_zoomed_render(zoom_factor)
 
         # fill the screen with a color to wipe away anything from last frame
         screen.fill(pygame.Color(150,150,150))

--- a/src/simulator/simulator.py
+++ b/src/simulator/simulator.py
@@ -23,7 +23,7 @@ from classes.edge import Edge
 from classes.route import Route
 from .render import render_world, render_manager, render_vehicles, render_buttons, render_time, render_toolbar, render_title
 from .update import update_world
-from .helper import set_zoomed_helper
+from .helper import set_zoomed_helper, scroll_handler
 
 def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: list[Edge], routes: list[Route], intersection_points, manager: Manager): # requires initialization of lanes, manager, vehicles
     pygame.init()
@@ -85,16 +85,7 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
 
             elif event.type == pygame.MOUSEWHEEL:
                 global zoom_factor
-                if event.y > 0:
-                    zoom_factor *= 1.1
-                    if zoom_factor > MAX_ZOOM_FACTOR:
-                        zoom_factor = MAX_ZOOM_FACTOR
-                elif event.y < 0:
-                    zoom_factor *= 0.9
-                    if zoom_factor < MIN_ZOOM_FACTOR:
-                        zoom_factor = MIN_ZOOM_FACTOR
-
-                set_zoomed_helper(zoom_factor)
+                zoom_factor = scroll_handler(event, zoom_factor)
 
         # fill the screen with a color to wipe away anything from last frame
         screen.fill(pygame.Color(150,150,150))

--- a/src/simulator/simulator.py
+++ b/src/simulator/simulator.py
@@ -20,9 +20,9 @@ from manager.manager import Manager, manager_event_loop
 from classes.node import Node
 from classes.edge import Edge
 from classes.route import Route
-from .render import render_world, render_manager, render_vehicles, render_buttons, render_time, render_toolbar, get_zoomed_render
+from .render import render_world, render_manager, render_vehicles, render_buttons, render_time, render_toolbar
 from .update import update_world
-from .helper import get_zoomed_helper
+from .helper import set_zoomed_helper
 
 def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: list[Edge], routes: list[Route], intersection_points, manager: Manager): # requires initialization of lanes, manager, vehicles
     pygame.init()
@@ -63,8 +63,7 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
             zoom_factor = MAX_ZOOM_FACTOR
         else:
             zoom_factor = 1
-        get_zoomed_render(zoom_factor)
-        get_zoomed_helper(zoom_factor)
+        set_zoomed_helper(zoom_factor)
     
     toggle_button = Button((40, 40, 40), (255, 50, 50), (5, screen.get_height()-TOOLBAR_HEIGHT+50), (100, 30), 'toggle update', toggle_update, ())
     restart_button = Button((40, 40, 40), (255, 50, 50), (110, screen.get_height()-TOOLBAR_HEIGHT+50), (100, 30), 'restart', restart_func, ())
@@ -92,8 +91,7 @@ def run_simulation(initial_vehicles: list[Vehicle], nodes: list[Node], edges: li
                     if zoom_factor > 1:
                         zoom_factor -= 1
 
-                get_zoomed_render(zoom_factor)
-                get_zoomed_helper(zoom_factor)
+                set_zoomed_helper(zoom_factor)
 
         # fill the screen with a color to wipe away anything from last frame
         screen.fill(pygame.Color(150,150,150))


### PR DESCRIPTION
managed to modify world_to_screen_vector function which significantly simplifies the code but the zoom state parameter still needs to be sent through the render functions. We receive the state of our zoom variable from the user's interaction with the button in simulator and since simulator does not call world_to_screen_vector directly, we need to pass zoomed as a parameter to a render function that can then  pass it along to the world_to_screen_vector function. 

Also, I made the chose not render the radius when zoomed in